### PR TITLE
Fix `Join` node behaviour

### DIFF
--- a/Nodes/Nodes.xcodeproj/project.pbxproj
+++ b/Nodes/Nodes.xcodeproj/project.pbxproj
@@ -28,6 +28,7 @@
 /* Begin PBXFileReference section */
 		E9220B6C2B8779FE00C4DE1D /* refs */ = {isa = PBXFileReference; lastKnownFileType = folder; name = refs; path = ../refs; sourceTree = "<group>"; };
 		E9252AA82B86308F00052FFE /* Logic */ = {isa = PBXFileReference; lastKnownFileType = wrapper; name = Logic; path = ../modules/Logic; sourceTree = "<group>"; };
+		E9770B7C2B908CF80065FDFF /* Nodes.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = file; path = Nodes.xctestplan; sourceTree = SOURCE_ROOT; };
 		E9BA0DF72B78E3080017240A /* Nodes.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Nodes.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		E9BA0DFA2B78E3080017240A /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		E9BA0E032B78E30A0017240A /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
@@ -83,11 +84,12 @@
 		E9BA0DF92B78E3080017240A /* Nodes */ = {
 			isa = PBXGroup;
 			children = (
-				E9BA0E692B78E6170017240A /* main.swift */,
-				E9BA0DFA2B78E3080017240A /* AppDelegate.swift */,
-				E9BA0E032B78E30A0017240A /* Assets.xcassets */,
-				E9BA0E052B78E30A0017240A /* LaunchScreen.storyboard */,
 				E9BA0E082B78E30A0017240A /* Info.plist */,
+				E9BA0DFA2B78E3080017240A /* AppDelegate.swift */,
+				E9BA0E692B78E6170017240A /* main.swift */,
+				E9BA0E032B78E30A0017240A /* Assets.xcassets */,
+				E9770B7C2B908CF80065FDFF /* Nodes.xctestplan */,
+				E9BA0E052B78E30A0017240A /* LaunchScreen.storyboard */,
 			);
 			path = Nodes;
 			sourceTree = "<group>";

--- a/Nodes/Nodes.xcodeproj/xcshareddata/xcschemes/Nodes.xcscheme
+++ b/Nodes/Nodes.xcodeproj/xcshareddata/xcschemes/Nodes.xcscheme
@@ -1,0 +1,77 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1520"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "E9BA0DF62B78E3080017240A"
+               BuildableName = "Nodes.app"
+               BlueprintName = "Nodes"
+               ReferencedContainer = "container:Nodes.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      shouldAutocreateTestPlan = "YES">
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "E9BA0DF62B78E3080017240A"
+            BuildableName = "Nodes.app"
+            BlueprintName = "Nodes"
+            ReferencedContainer = "container:Nodes.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "E9BA0DF62B78E3080017240A"
+            BuildableName = "Nodes.app"
+            BlueprintName = "Nodes"
+            ReferencedContainer = "container:Nodes.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/Nodes/Nodes.xcodeproj/xcshareddata/xcschemes/Nodes.xcscheme
+++ b/Nodes/Nodes.xcodeproj/xcshareddata/xcschemes/Nodes.xcscheme
@@ -26,8 +26,13 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      shouldUseLaunchSchemeArgsEnv = "YES"
-      shouldAutocreateTestPlan = "YES">
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <TestPlans>
+         <TestPlanReference
+            reference = "container:Nodes.xctestplan"
+            default = "YES">
+         </TestPlanReference>
+      </TestPlans>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"

--- a/Nodes/Nodes.xcodeproj/xcshareddata/xcschemes/NodesTests.xcscheme
+++ b/Nodes/Nodes.xcodeproj/xcshareddata/xcschemes/NodesTests.xcscheme
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1520"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      shouldAutocreateTestPlan = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO"
+            parallelizable = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "E9BA0E0C2B78E30A0017240A"
+               BuildableName = "NodesTests.xctest"
+               BlueprintName = "NodesTests"
+               ReferencedContainer = "container:Nodes.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/Nodes/Nodes.xctestplan
+++ b/Nodes/Nodes.xctestplan
@@ -1,0 +1,24 @@
+{
+  "configurations" : [
+    {
+      "id" : "CAA3A1D4-234A-4C04-9196-56048DE28C86",
+      "name" : "Configuration 1",
+      "options" : {
+
+      }
+    }
+  ],
+  "defaultOptions" : {
+
+  },
+  "testTargets" : [
+    {
+      "target" : {
+        "containerPath" : "container:..\/modules\/Logic",
+        "identifier" : "LogicTests",
+        "name" : "LogicTests"
+      }
+    }
+  ],
+  "version" : 1
+}

--- a/modules/App/Sources/App/Controllers/NodeLinkController.swift
+++ b/modules/App/Sources/App/Controllers/NodeLinkController.swift
@@ -49,7 +49,7 @@ final class NodeLinkController: LinkController, ObservableObject {
         nodes.append(nodesType.randomElement()!.init())
     }
 
-    private func link(input: NodeInput, position: Int, output: PassthroughSubject<String?, Never>, tappedPoint: Binding<CGPoint>, point: Binding<CGPoint>) {
+    private func link(input: NodeInput, position: Int, output: CurrentValueSubject<String?, Never>, tappedPoint: Binding<CGPoint>, point: Binding<CGPoint>) {
         input.linkInput(output, position: position)
         points.append(Link(from: tappedPoint, to: point))
         clear()

--- a/modules/App/Sources/App/Controllers/NodeParam.swift
+++ b/modules/App/Sources/App/Controllers/NodeParam.swift
@@ -6,5 +6,5 @@ import Logic
 
 enum NodeParam {
     case input(NodeInput, Int)
-    case output(PassthroughSubject<String?, Never>)
+    case output(CurrentValueSubject<String?, Never>)
 }

--- a/modules/Logic/Sources/Logic/ConstantString.swift
+++ b/modules/Logic/Sources/Logic/ConstantString.swift
@@ -1,0 +1,18 @@
+//  ConstantString.swift
+//  Created by Aiur Arkhipov on 27.02.2024.
+
+import Combine
+
+public class ConstantString {
+    public var output: PassthroughSubject<String?, Never> = .init()
+
+    private var string: String
+
+    public init(_ string: String) {
+        self.string = string
+    }
+
+    public func run() {
+        output.send(string)
+    }
+}

--- a/modules/Logic/Sources/Logic/ConstantString.swift
+++ b/modules/Logic/Sources/Logic/ConstantString.swift
@@ -4,7 +4,7 @@
 import Combine
 
 public class ConstantString {
-    public var output: PassthroughSubject<String?, Never> = .init()
+    public var output: CurrentValueSubject<String?, Never> = .init(nil)
 
     private var string: String
 

--- a/modules/Logic/Sources/Logic/Display.swift
+++ b/modules/Logic/Sources/Logic/Display.swift
@@ -5,7 +5,7 @@ import Combine
 
 public final class Display: NodeInput {
     public var input: AnyPublisher<String?, Never> = CurrentValueSubject.init("").eraseToAnyPublisher()
-    public var output: PassthroughSubject<String?, Never> = .init()
+    public var output: CurrentValueSubject<String?, Never> = .init("")
 
     public var action: ((_: String?) -> Void)? = {
         print($0 ?? "nil")
@@ -15,7 +15,7 @@ public final class Display: NodeInput {
 
     public init() {}
 
-    public func linkInput(_ input: PassthroughSubject<String?, Never>, position: Int) {
+    public func linkInput(_ input: CurrentValueSubject<String?, Never>, position: Int) {
         if position == 0 {
             linkInput(input)
         } else {
@@ -23,7 +23,7 @@ public final class Display: NodeInput {
         }
     }
 
-    public func linkInput(_ link: PassthroughSubject<String?, Never>) {
+    public func linkInput(_ link: CurrentValueSubject<String?, Never>) {
         input = link.eraseToAnyPublisher()
         listener = input
             .sink { [weak self] (input) in

--- a/modules/Logic/Sources/Logic/Join.swift
+++ b/modules/Logic/Sources/Logic/Join.swift
@@ -6,13 +6,13 @@ import Combine
 public class Join: NodeInput {
     public var input1: AnyPublisher<String?, Never> = CurrentValueSubject.init("").eraseToAnyPublisher()
     public var input2: AnyPublisher<String?, Never> = CurrentValueSubject.init("").eraseToAnyPublisher()
-    public var output: PassthroughSubject<String?, Never> = .init()
+    public var output: CurrentValueSubject<String?, Never> = .init(nil)
 
     private var listener: AnyCancellable?
 
     public init() {}
 
-    public func linkInput(_ input: PassthroughSubject<String?, Never>, position: Int) {
+    public func linkInput(_ input: CurrentValueSubject<String?, Never>, position: Int) {
         if position == 0 {
             linkParamOne(input)
         } else if position == 1 {
@@ -22,12 +22,12 @@ public class Join: NodeInput {
         }
     }
 
-    func linkParamOne(_ link: PassthroughSubject<String?, Never>) {
+    func linkParamOne(_ link: CurrentValueSubject<String?, Never>) {
         input1 = link.eraseToAnyPublisher()
         subscribe()
     }
 
-    func linkParamTwo(_ link: PassthroughSubject<String?, Never>) {
+    func linkParamTwo(_ link: CurrentValueSubject<String?, Never>) {
         input2 = link.eraseToAnyPublisher()
         subscribe()
     }

--- a/modules/Logic/Sources/Logic/Join.swift
+++ b/modules/Logic/Sources/Logic/Join.swift
@@ -6,7 +6,7 @@ import Combine
 public class Join: NodeInput {
     public var input1: AnyPublisher<String?, Never> = CurrentValueSubject.init("").eraseToAnyPublisher()
     public var input2: AnyPublisher<String?, Never> = CurrentValueSubject.init("").eraseToAnyPublisher()
-    public var output: CurrentValueSubject<String?, Never> = .init(nil)
+    public var output: CurrentValueSubject<String?, Never> = .init("")
 
     private var listener: AnyCancellable?
 

--- a/modules/Logic/Sources/Logic/NodeInput.swift
+++ b/modules/Logic/Sources/Logic/NodeInput.swift
@@ -4,5 +4,5 @@
 import Combine
 
 public protocol NodeInput {
-    func linkInput(_ input: PassthroughSubject<String?, Never>, position: Int)
+    func linkInput(_ input: CurrentValueSubject<String?, Never>, position: Int)
 }

--- a/modules/Logic/Sources/Logic/RandomLetter.swift
+++ b/modules/Logic/Sources/Logic/RandomLetter.swift
@@ -4,7 +4,7 @@
 import Combine
 
 public class RandomLetter {
-    public var output: PassthroughSubject<String?, Never> = .init()
+    public var output: CurrentValueSubject<String?, Never> = .init(nil)
 
     public init() {}
 

--- a/modules/Logic/Tests/LogicTests/NodesTests.swift
+++ b/modules/Logic/Tests/LogicTests/NodesTests.swift
@@ -2,9 +2,8 @@
 //  Created by Vladimir Roganov on 21.02.2024
 
 import XCTest
-@testable import Logic
-
 import Combine
+@testable import Logic
 
 final class NodesTests: XCTestCase {
     private var listeners: Set<AnyCancellable> = .init()
@@ -12,14 +11,14 @@ final class NodesTests: XCTestCase {
     func testRandomLetter_OuputsSingleLetter() throws {
         let sut = RandomLetter()
 
-        var output: String?
+        var result: String?
         sut.output.sink {
-            output = $0
+            result = $0
         }.store(in: &listeners)
 
         sut.run()
 
-        XCTAssertEqual(output?.count, 1)
+        XCTAssertEqual(result?.count, 1)
     }
 
     func testRandomLetter_OutputsDifferentRandomLetters() throws {
@@ -49,14 +48,14 @@ final class NodesTests: XCTestCase {
         let paramSubject = CurrentValueSubject<String?, Never>(nil)
         sut.linkParamOne(paramSubject)
 
-        var output: String?
+        var result: String?
         sut.output.sink {
-            output = $0
+            result = $0
         }.store(in: &listeners)
 
         paramSubject.send(param)
 
-        XCTAssertEqual(param, output)
+        XCTAssertEqual(param, result)
     }
 
     func testJoin_WithBothParams_OneWithoutSend_NotOutputsParamString() throws {
@@ -70,35 +69,35 @@ final class NodesTests: XCTestCase {
         sut.linkParamOne(constStringNodeA.output)
         sut.linkParamTwo(constStringNodeB.output)
 
-        var output: String?
+        var result: String?
         sut.output.sink {
-            output = $0
+            result = $0
         }.store(in: &listeners)
 
         constStringNodeA.run()
 
-        XCTAssertEqual(paramA, output)
+        XCTAssertEqual(paramA, result)
     }
 
     func testJoin_WithBothParams_OutputsCombinedString() throws {
         let sut = Join()
-        let param = "Hello"
+        let param1 = "Hello"
         let param2 = "World"
 
-        let paramSubject = CurrentValueSubject<String?, Never>(nil)
-        sut.linkParamOne(paramSubject)
+        let param1Subject = CurrentValueSubject<String?, Never>(nil)
+        sut.linkParamOne(param1Subject)
         let param2Subject = CurrentValueSubject<String?, Never>(nil)
         sut.linkParamTwo(param2Subject)
 
-        var output: String?
+        var result: String?
         sut.output.sink {
-            output = $0
+            result = $0
         }.store(in: &listeners)
 
-        paramSubject.send(param)
+        param1Subject.send(param1)
         param2Subject.send(param2)
 
-        XCTAssertEqual(output, param + param2)
+        XCTAssertEqual(result, param1 + param2)
     }
 
     func testDisplay_OutputsAndPrintReceivedValue() throws {
@@ -109,9 +108,9 @@ final class NodesTests: XCTestCase {
 
         sut.linkInput(paramSubject)
 
-        var output: String?
+        var result: String?
         sut.output.sink {
-            output = $0
+            result = $0
         }.store(in: &listeners)
 
         var printedValue: String?
@@ -121,25 +120,24 @@ final class NodesTests: XCTestCase {
 
         paramSubject.send(param)
 
-        XCTAssertEqual(output, param)
+        XCTAssertEqual(result, param)
         XCTAssertEqual(printedValue, param)
     }
 
     func testTwoRandomLettersJoined_OutputsCorrectStringLength() throws {
-        let sut = RandomLetter()
+        let sut1 = RandomLetter()
         let sut2 = Join()
 
-        sut2.linkParamOne(sut.output)
-        sut2.linkParamTwo(sut.output)
+        sut2.linkParamOne(sut1.output)
+        sut2.linkParamTwo(sut1.output)
 
-        var output: String?
+        var result: String?
         sut2.output.sink {
-            output = $0
+            result = $0
         }.store(in: &listeners)
 
-        sut.run()
+        sut1.run()
 
-        XCTAssertEqual(output?.count, 2)
+        XCTAssertEqual(result?.count, 2)
     }
 }
-

--- a/modules/Logic/Tests/LogicTests/NodesTests.swift
+++ b/modules/Logic/Tests/LogicTests/NodesTests.swift
@@ -60,7 +60,7 @@ final class NodesTests: XCTestCase {
 
         var output: String?
 
-        let paramSubject = PassthroughSubject<String?, Never>()
+        let paramSubject = CurrentValueSubject<String?, Never>(nil)
         sut.linkParamOne(paramSubject)
 
         sut.output.sink {
@@ -77,11 +77,6 @@ final class NodesTests: XCTestCase {
 
     func testJoin_WithBothParams_OneWithoutSend_NotOutputsParamString() throws {
         let sut = Join()
-        let param = "Hello"
-
-        let exp = self.expectation(description: "Output")
-
-        var output: String?
 
         let paramA = "A"
         let paramB = "B"
@@ -91,14 +86,12 @@ final class NodesTests: XCTestCase {
         sut.linkParamOne(constStringNodeA.output)
         sut.linkParamTwo(constStringNodeB.output)
 
+        var output: String?
         sut.output.sink {
             output = $0
-            exp.fulfill()
         }.store(in: &listeners)
 
         constStringNodeA.run()
-
-        waitForExpectations(timeout: 0.3) // Fail
 
         XCTAssertEqual(paramA, output)
     }
@@ -112,9 +105,9 @@ final class NodesTests: XCTestCase {
 
         var output: String?
 
-        let paramSubject = PassthroughSubject<String?, Never>()
+        let paramSubject = CurrentValueSubject<String?, Never>(nil)
         sut.linkParamOne(paramSubject)
-        let param2Subject = PassthroughSubject<String?, Never>()
+        let param2Subject = CurrentValueSubject<String?, Never>(nil)
         sut.linkParamTwo(param2Subject)
 
         sut.output.sink {
@@ -136,7 +129,7 @@ final class NodesTests: XCTestCase {
 
         let exp = self.expectation(description: "Output")
 
-        let paramSubject = PassthroughSubject<String?, Never>()
+        let paramSubject = CurrentValueSubject<String?, Never>(nil)
 
         sut.linkInput(paramSubject)
 

--- a/modules/Logic/Tests/LogicTests/NodesTests.swift
+++ b/modules/Logic/Tests/LogicTests/NodesTests.swift
@@ -75,6 +75,34 @@ final class NodesTests: XCTestCase {
         XCTAssertEqual(param, output)
     }
 
+    func testJoin_WithBothParams_OneWithoutSend_NotOutputsParamString() throws {
+        let sut = Join()
+        let param = "Hello"
+
+        let exp = self.expectation(description: "Output")
+
+        var output: String?
+
+        let paramA = "A"
+        let paramB = "B"
+        let constStringNodeA = ConstantString(paramA)
+        let constStringNodeB = ConstantString(paramB)
+
+        sut.linkParamOne(constStringNodeA.output)
+        sut.linkParamTwo(constStringNodeB.output)
+
+        sut.output.sink {
+            output = $0
+            exp.fulfill()
+        }.store(in: &listeners)
+
+        constStringNodeA.run()
+
+        waitForExpectations(timeout: 0.3) // Fail
+
+        XCTAssertEqual(paramA, output)
+    }
+
     func testJoin_WithBothParams_OutputsCombinedString() throws {
         let sut = Join()
         let param = "Hello"

--- a/modules/Logic/Tests/LogicTests/NodesTests.swift
+++ b/modules/Logic/Tests/LogicTests/NodesTests.swift
@@ -11,18 +11,15 @@ final class NodesTests: XCTestCase {
 
     func testRandomLetter_OuputsSingleLetter() throws {
         let sut = RandomLetter()
+
         var output: String?
-        let expectation = self.expectation(description: "Output")
         sut.output.sink {
             output = $0
-            expectation.fulfill()
         }.store(in: &listeners)
 
         sut.run()
 
-        waitForExpectations(timeout: 0.3)
-        let outputString = try XCTUnwrap(output)
-        XCTAssertEqual(outputString.count, 1)
+        XCTAssertEqual(output?.count, 1)
     }
 
     func testRandomLetter_OutputsDifferentRandomLetters() throws {
@@ -30,47 +27,34 @@ final class NodesTests: XCTestCase {
 
         var letter1: String?
         var letter2: String?
-
-        let exp = self.expectation(description: "Output")
-
         sut.output.collect(2).sink { value in
             letter1 = value.first ?? nil
             letter2 = value.last ?? nil
-            exp.fulfill()
         }.store(in: &listeners)
 
         sut.run()
         sut.run()
 
-        waitForExpectations(timeout: 0.3)
-
         XCTAssertNotEqual(letter1, letter2)
     }
 
     func testJoin_OutputsEmptyString_WithoutParams() throws {
-        let sut = Join()
-        XCTAssertNotNil(sut.output)
+        XCTAssertNotNil(Join().output.value)
     }
 
     func testJoin_WithSingleParam_OutputsParamString() throws {
         let sut = Join()
         let param = "Hello"
 
-        let exp = self.expectation(description: "Output")
-
-        var output: String?
-
         let paramSubject = CurrentValueSubject<String?, Never>(nil)
         sut.linkParamOne(paramSubject)
 
+        var output: String?
         sut.output.sink {
             output = $0
-            exp.fulfill()
         }.store(in: &listeners)
 
         paramSubject.send(param)
-
-        waitForExpectations(timeout: 0.3)
 
         XCTAssertEqual(param, output)
     }
@@ -101,24 +85,18 @@ final class NodesTests: XCTestCase {
         let param = "Hello"
         let param2 = "World"
 
-        let exp = self.expectation(description: "Output")
-
-        var output: String?
-
         let paramSubject = CurrentValueSubject<String?, Never>(nil)
         sut.linkParamOne(paramSubject)
         let param2Subject = CurrentValueSubject<String?, Never>(nil)
         sut.linkParamTwo(param2Subject)
 
+        var output: String?
         sut.output.sink {
             output = $0
-            exp.fulfill()
         }.store(in: &listeners)
 
         paramSubject.send(param)
         param2Subject.send(param2)
-
-        waitForExpectations(timeout: 0.3)
 
         XCTAssertEqual(output, param + param2)
     }
@@ -127,28 +105,21 @@ final class NodesTests: XCTestCase {
         let sut = Display()
         let param = "Hello"
 
-        let exp = self.expectation(description: "Output")
-
         let paramSubject = CurrentValueSubject<String?, Never>(nil)
 
         sut.linkInput(paramSubject)
 
         var output: String?
-
         sut.output.sink {
             output = $0
-            exp.fulfill()
         }.store(in: &listeners)
 
         var printedValue: String?
-
         sut.action = {
             printedValue = $0
         }
 
         paramSubject.send(param)
-
-        waitForExpectations(timeout: 0.3)
 
         XCTAssertEqual(output, param)
         XCTAssertEqual(printedValue, param)
@@ -158,27 +129,17 @@ final class NodesTests: XCTestCase {
         let sut = RandomLetter()
         let sut2 = Join()
 
-        let exp = self.expectation(description: "Output")
-
         sut2.linkParamOne(sut.output)
         sut2.linkParamTwo(sut.output)
 
         var output: String?
-
         sut2.output.sink {
             output = $0
-            exp.fulfill()
         }.store(in: &listeners)
 
         sut.run()
 
-        waitForExpectations(timeout: 0.3)
-
         XCTAssertEqual(output?.count, 2)
-    }
-
-    func testAll() throws {
-
     }
 }
 


### PR DESCRIPTION
- replaced `PassthroughSubject` with `CurrentValueSubject`
- improved test readability and performance